### PR TITLE
fixes the incorrect call to the nonexistent var "running"

### DIFF
--- a/public/javascripts/app.js
+++ b/public/javascripts/app.js
@@ -1,5 +1,5 @@
 // App js
 (function() {
 	var go = 'running!';
-	console.log( running );
+	console.log( go );
 })();


### PR DESCRIPTION
Instead of the variable "running" being called by console.log, this changes that call to the var "go".
